### PR TITLE
feat: 사용자 인증/인가 기능 구현 (Google OAuth & JWT 발급) (#4)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,15 @@
 APP_NAME=Job Navigator
 ENVIRONMENT=development
 CORS_ALLOWED_ORIGINS=http://localhost:5173
+
+POSTGRES_USER=your_username
+POSTGRES_PASSWORD=your_password
+POSTGRES_DB=your_database
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+
+GOOGLE_CLIENT_ID=193041303181-kpnshqivt6q8ep39omfalo9s8uaih2ta.apps.googleusercontent.com
+
+JWT_SECRET_KEY=mysupersecretkey
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=60

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,0 +1,20 @@
+# 데이터베이스 연결 설정 파일
+
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from dotenv import load_dotenv
+
+load_dotenv()
+
+POSTGRES_USER = os.getenv("POSTGRES_USER")
+POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD")
+POSTGRES_DB = os.getenv("POSTGRES_DB")
+POSTGRES_HOST = os.getenv("POSTGRES_HOST")
+POSTGRES_PORT = os.getenv("POSTGRES_PORT")
+
+SQLALCHEMY_DATABASE_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL)
+
+sessionmaker = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -17,4 +17,4 @@ SQLALCHEMY_DATABASE_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{PO
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 
-sessionmaker = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,4 +43,4 @@ def read_root():
 
 app.include_router(job.router, prefix="/api/v1/jobs", tags=["Jobs"])
 
-app.include_router(auth.router, prefix="api/v1/auth", tags=["auth"])
+app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.routes import job
 from app.services import job_service
 from app.core.config import load_env, get_settings
+from app.routes import auth
+from app.models.user import Base
+from app.core.database import engine
 
 # ✅ .env 파일 로드
 load_env()
@@ -23,6 +26,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# DB 테이블 생성
+# PgAdmin에서 쿼리문으로 이미 테이블 생성했음 -> 주석처리해도 무관
+Base.metadata.create_all(bind=engine)
+
 
 @app.on_event("startup")
 def startup_event():
@@ -35,3 +42,5 @@ def read_root():
 
 
 app.include_router(job.router, prefix="/api/v1/jobs", tags=["Jobs"])
+
+app.include_router(auth.router, prefix="api/v1/auth", tags=["auth"])

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,59 @@
+# 사용자(User) 테이블의 DB 모델 정의 파일
+
+from sqlalchemy import Column, Integer, String, Boolean, DataTime, func
+from sqlalchemy.orm import declarative_base
+
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+from datetime import datetime
+
+Base = declarative_base
+
+
+# User 테이블 정의
+class User(Base):
+    __tablename__ = "users"
+
+    """
+    user_id : 기본키
+    social_provider : 소셜 로그인 제공자 (ex: google, naver, kakao)
+    social_id : 소셜로그인 ID(소셜 플랫폼 고유 ID)
+    email : 사용자 이메일
+    name : 사용자 이름
+    profile_image = 프로필 이미지 URL
+    is_active : 계정 활성화 상태
+    create_at : 생성일
+    """
+
+    user_id = Column(Integer, primary_key=True, index=True)
+    social_provider = Column(String(20), nullable=False)
+    social_id = Column(String(100), unique=True, nullable=False)
+    email = Column(String(100), unique=True, nullable=False)
+    name = Column(String(100))
+    profile_image = Column(String(300))
+    is_active = Column(Boolean, default=True)
+    create_at = Column(DataTime(timezone=True), server_default=func.now())
+
+
+# 회원가입 요청 시 사용할 데이터 구조(사용자 생성 시 프론트에서 넘어오는 데이터 구조)
+class UserCreate(BaseModel):
+    social_provider: str
+    social_id: str
+    email: EmailStr
+    name: Optional[str] = None
+    profile_image: Optional[str] = None
+
+
+# DB에 저장된 사용자 데이터를 클라이언트로 반환할 때 사용되는 스키마
+class UserResponse(BaseModel):
+    user_id: int
+    social_provider: str
+    social_id: str
+    email: EmailStr
+    name: Optional[str] = None
+    profile_image: Optional[str] = None
+    is_active: bool
+    create_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,13 +1,13 @@
 # 사용자(User) 테이블의 DB 모델 정의 파일
 
-from sqlalchemy import Column, Integer, String, Boolean, DataTime, func
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, func
 from sqlalchemy.orm import declarative_base
 
 from pydantic import BaseModel, EmailStr
 from typing import Optional
 from datetime import datetime
 
-Base = declarative_base
+Base = declarative_base()
 
 
 # User 테이블 정의
@@ -32,16 +32,12 @@ class User(Base):
     name = Column(String(100))
     profile_image = Column(String(300))
     is_active = Column(Boolean, default=True)
-    create_at = Column(DataTime(timezone=True), server_default=func.now())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
 # 회원가입 요청 시 사용할 데이터 구조(사용자 생성 시 프론트에서 넘어오는 데이터 구조)
 class UserCreate(BaseModel):
-    social_provider: str
-    social_id: str
-    email: EmailStr
-    name: Optional[str] = None
-    profile_image: Optional[str] = None
+    id_token_str: str
 
 
 # DB에 저장된 사용자 데이터를 클라이언트로 반환할 때 사용되는 스키마
@@ -53,7 +49,8 @@ class UserResponse(BaseModel):
     name: Optional[str] = None
     profile_image: Optional[str] = None
     is_active: bool
-    create_at: datetime
+    created_at: datetime
+    access_token: str
 
     class Config:
-        orm_mode = True
+        from_attribute = True

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -38,8 +38,10 @@ def create_access_token(data: dict, expires_delta: timedelta = None):
 
 # Google 로그인 엔드포인트
 @router.post("/google-login", response_model=UserResponse)
-def google_login(id_token_str, db: Session = Depends(get_db)):
+def google_login(request: UserCreate, db: Session = Depends(get_db)):
     try:
+        id_token_str = request.id_token_str
+
         # 구글 ID 토큰 검증
         id_info = id_token.verify_oauth2_token(
             id_token_str, google_requests.Request(), GOOGLE_CLIENT_ID
@@ -86,11 +88,12 @@ def google_login(id_token_str, db: Session = Depends(get_db)):
         return {
             "user_id": user.user_id,
             "social_provider": user.social_provider,
+            "social_id": user.social_id,
             "email": user.email,
             "name": user.name,
             "profile_image": user.profile_image,
             "is_active": user.is_active,
-            "create_at": user.create_at,
+            "created_at": user.created_at,
             "access_token": token,
         }
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,0 +1,98 @@
+# 소셜 로그인 API 및 JWT 발급 처리
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from google.oauth2 import id_token
+from google.auth.transport import requests as google_requests
+from datetime import datetime, timedelta
+from jose import jwt
+import os
+
+from app.core.database import SessionLocal
+from app.models.user import User, UserCreate, UserResponse
+
+GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
+JWT_ALGORITHM = os.getenv("JWT_ALGORITHM")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES"))
+
+router = APIRouter()
+
+
+# DB 세션 생성
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# JWT 토큰 생성 함수
+def create_access_token(data: dict, expires_delta: timedelta = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+    return encoded_jwt
+
+
+# Google 로그인 엔드포인트
+@router.post("/google-login", response_model=UserResponse)
+def google_login(id_token_str, db: Session = Depends(get_db)):
+    try:
+        # 구글 ID 토큰 검증
+        id_info = id_token.verify_oauth2_token(
+            id_token_str, google_requests.Request(), GOOGLE_CLIENT_ID
+        )
+
+        # 구글 유저 정보 추출
+        social_provider = "google"
+        social_id = id_info["sub"]
+        email = id_info["email"]
+        name = id_info.get("name")
+        profile_image = id_info.get("picture")
+
+        # DB에서 기존 유저 확인
+        user = (
+            db.query(User)
+            .filter(
+                User.social_id == social_id, User.social_provider == social_provider
+            )
+            .first()
+        )
+
+        # 신규 유저 회원가입 처리
+        if not user:
+            new_user = User(
+                social_provider=social_provider,
+                social_id=social_id,
+                email=email,
+                name=name,
+                profile_image=profile_image,
+                is_active=True,
+            )
+            db.add(new_user)
+            db.commit()
+            db.refresh(new_user)
+            user = new_user
+
+        # JWT 발급
+        token = create_access_token(
+            data={"user_id": user.user_id},
+            expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+        )
+
+        # 응답 반환
+        return {
+            "user_id": user.user_id,
+            "social_provider": user.social_provider,
+            "email": user.email,
+            "name": user.name,
+            "profile_image": user.profile_image,
+            "is_active": user.is_active,
+            "create_at": user.create_at,
+            "access_token": token,
+        }
+
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid Google token")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,5 @@ pydantic-settings
 black
 pytest
 httpx
+google-auth
+python-jose

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,5 +6,9 @@ pydantic-settings
 black
 pytest
 httpx
-google-auth
 python-jose
+sqlalchemy
+pytest-mock
+google-auth[requests]
+psycopg2-binary
+pydantic[email]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,42 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from unittest.mock import patch
+from app.routes import auth
+
+client = TestClient(app)
+
+
+# ✅ 실패 케이스: 잘못된 토큰일 때
+def test_google_login_invalid_token():
+    response = client.post(
+        "/api/v1/auth/google-login", json={"id_token_str": "invalid_token"}
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid Google token"
+
+
+# ✅ 성공 케이스: mocking을 이용해서 구글 토큰 검증 우회
+@patch("app.routes.auth.id_token.verify_oauth2_token")
+def test_google_login_success(mock_verify_token):
+    # ✅ mocking된 구글 토큰 응답 값 정의
+    mock_verify_token.return_value = {
+        "sub": "mocked_social_id_12345",
+        "email": "testuser@example.com",
+        "name": "테스트 사용자",
+        "picture": "http://test.image.url",
+    }
+
+    response = client.post(
+        "/api/v1/auth/google-login", json={"id_token_str": "any_valid_token_string"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # ✅ 응답 필드 검증
+    assert data["user_id"] > 0
+    assert data["email"] == "testuser@example.com"
+    assert "access_token" in data
+
+    # ✅ JWT 토큰 유효성은 별도 테스트 가능 (간단 예시로 존재 확인)


### PR DESCRIPTION
## 개요

- 이슈 #4 사용자 인증/인가 기능을 구현했습니다.
- Google OAuth 기반 소셜 로그인 및 JWT 발급 기능을 추가하고, 기존 API와 통합했습니다.

## 주요 변경사항

### Backend

- `models/user.py` : User ORM 모델 및 Pydantic 스키마 통합 작성
- `core/database.py` : DB 연결 설정 (환경변수 기반)
- `routers/auth.py` : Google 소셜 로그인 API 및 JWT 발급 구현
- `main.py` : auth 라우터 등록 및 전체 API 경로 일관성 통일 (`/api/v1`)
- `.env.example` : 소셜 로그인 및 JWT 환경변수 예시 추가
- `requirements.txt` : google-auth, python-jose 등 의존성 패키지 추가

## 참고사항

- [x] **테스트코드 추가 예정 (추후 pytest 기반으로 작성 계획)**
- [ ] 추후 네이버, 카카오 소셜 로그인 확장 예정
- 현재 JWT 기반 인증 API까지 구현 완료
- black으로 코드 스타일 포맷팅 적용 완료


## 관련 이슈

- closes #4
