### PR TITLE
feat: 카카오 및 네이버 로그인 기능 추가

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,14 +2,26 @@ APP_NAME=Job Navigator
 ENVIRONMENT=development
 CORS_ALLOWED_ORIGINS=http://localhost:5173
 
+# PostgreSQL 설정
 POSTGRES_USER=your_username
 POSTGRES_PASSWORD=your_password
 POSTGRES_DB=your_database
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 
-GOOGLE_CLIENT_ID=193041303181-kpnshqivt6q8ep39omfalo9s8uaih2ta.apps.googleusercontent.com
+# Google OAuth 설정
+GOOGLE_CLIENT_ID=your_google_client_id
 
-JWT_SECRET_KEY=mysupersecretkey
+# Kakao OAuth 설정
+KAKAO_CLIENT_ID=your_kakao_rest_api_key
+KAKAO_REDIRECT_URI=http://localhost:8000/api/v1/auth/kakao/callback
+
+# Naver OAuth 설정
+NAVER_CLIENT_ID=your_naver_client_id
+NAVER_CLIENT_SECRET=your_naver_client_secret
+NAVER_REDIRECT_URI=http://localhost:8000/api/v1/auth/naver/callback
+
+# JWT 설정
+JWT_SECRET_KEY=your_jwt_secret_key
 JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=60

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,24 +1,31 @@
-# 소셜 로그인 API 및 JWT 발급 처리
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 from google.oauth2 import id_token
 from google.auth.transport import requests as google_requests
 from datetime import datetime, timedelta
 from jose import jwt
+import requests
 import os
 
 from app.core.database import SessionLocal
 from app.models.user import User, UserCreate, UserResponse
 
+router = APIRouter()
+
+# === 환경변수 ===
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
+KAKAO_CLIENT_ID = os.getenv("KAKAO_CLIENT_ID")
+KAKAO_REDIRECT_URI = os.getenv("KAKAO_REDIRECT_URI")
+NAVER_CLIENT_ID = os.getenv("NAVER_CLIENT_ID")
+NAVER_CLIENT_SECRET = os.getenv("NAVER_CLIENT_SECRET")
+NAVER_REDIRECT_URI = os.getenv("NAVER_REDIRECT_URI")
 JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
 JWT_ALGORITHM = os.getenv("JWT_ALGORITHM")
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES"))
+FRONTEND_REDIRECT = "http://localhost:5173/login"
 
-router = APIRouter()
-
-
-# DB 세션 생성
+# === DB 세션 ===
 def get_db():
     db = SessionLocal()
     try:
@@ -26,46 +33,34 @@ def get_db():
     finally:
         db.close()
 
-
-# JWT 토큰 생성 함수
+# === JWT 생성 ===
 def create_access_token(data: dict, expires_delta: timedelta = None):
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
     to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
-    return encoded_jwt
+    return jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
 
-
-# Google 로그인 엔드포인트
+# ✅ 1. Google 로그인
 @router.post("/google-login", response_model=UserResponse)
 def google_login(request: UserCreate, db: Session = Depends(get_db)):
     try:
         id_token_str = request.id_token_str
-
-        # 구글 ID 토큰 검증
         id_info = id_token.verify_oauth2_token(
             id_token_str, google_requests.Request(), GOOGLE_CLIENT_ID
         )
 
-        # 구글 유저 정보 추출
         social_provider = "google"
         social_id = id_info["sub"]
         email = id_info["email"]
         name = id_info.get("name")
         profile_image = id_info.get("picture")
 
-        # DB에서 기존 유저 확인
-        user = (
-            db.query(User)
-            .filter(
-                User.social_id == social_id, User.social_provider == social_provider
-            )
-            .first()
-        )
+        user = db.query(User).filter(
+            User.social_id == social_id, User.social_provider == social_provider
+        ).first()
 
-        # 신규 유저 회원가입 처리
         if not user:
-            new_user = User(
+            user = User(
                 social_provider=social_provider,
                 social_id=social_id,
                 email=email,
@@ -73,18 +68,15 @@ def google_login(request: UserCreate, db: Session = Depends(get_db)):
                 profile_image=profile_image,
                 is_active=True,
             )
-            db.add(new_user)
+            db.add(user)
             db.commit()
-            db.refresh(new_user)
-            user = new_user
+            db.refresh(user)
 
-        # JWT 발급
         token = create_access_token(
             data={"user_id": user.user_id},
             expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
         )
 
-        # 응답 반환
         return {
             "user_id": user.user_id,
             "social_provider": user.social_provider,
@@ -99,3 +91,119 @@ def google_login(request: UserCreate, db: Session = Depends(get_db)):
 
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid Google token")
+
+# ✅ 2. Kakao 로그인
+@router.get("/kakao-login")
+def kakao_login():
+    return RedirectResponse(
+        f"https://kauth.kakao.com/oauth/authorize"
+        f"?client_id={KAKAO_CLIENT_ID}&redirect_uri={KAKAO_REDIRECT_URI}&response_type=code"
+    )
+
+@router.get("/kakao/callback")
+def kakao_callback(code: str, db: Session = Depends(get_db)):
+    token_res = requests.post(
+        "https://kauth.kakao.com/oauth/token",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "grant_type": "authorization_code",
+            "client_id": KAKAO_CLIENT_ID,
+            "redirect_uri": KAKAO_REDIRECT_URI,
+            "code": code,
+        },
+    )
+    if token_res.status_code != 200:
+        raise HTTPException(status_code=400, detail="카카오 토큰 요청 실패")
+
+    access_token = token_res.json().get("access_token")
+
+    profile_res = requests.get(
+        "https://kapi.kakao.com/v2/user/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    if profile_res.status_code != 200:
+        raise HTTPException(status_code=400, detail="카카오 사용자 정보 요청 실패")
+
+    kakao_info = profile_res.json()
+    kakao_id = str(kakao_info["id"])
+    email = kakao_info["kakao_account"].get("email") or f"{kakao_id}@kakao.com"
+    name = kakao_info["properties"].get("nickname")
+    profile_image = kakao_info["properties"].get("profile_image")
+
+    user = db.query(User).filter(
+        User.social_id == kakao_id, User.social_provider == "kakao"
+    ).first()
+    if not user:
+        user = User(
+            social_provider="kakao",
+            social_id=kakao_id,
+            email=email,
+            name=name,
+            profile_image=profile_image,
+            is_active=True,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    token = create_access_token(data={"user_id": user.user_id})
+    return RedirectResponse(f"{FRONTEND_REDIRECT}?token={token}")
+
+# ✅ 3. Naver 로그인
+@router.get("/naver-login")
+def naver_login():
+    return RedirectResponse(
+        f"https://nid.naver.com/oauth2.0/authorize"
+        f"?client_id={NAVER_CLIENT_ID}&response_type=code"
+        f"&redirect_uri={NAVER_REDIRECT_URI}&state=xyz"
+    )
+
+@router.get("/naver/callback")
+def naver_callback(code: str, state: str, db: Session = Depends(get_db)):
+    token_res = requests.post(
+        "https://nid.naver.com/oauth2.0/token",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "grant_type": "authorization_code",
+            "client_id": NAVER_CLIENT_ID,
+            "client_secret": NAVER_CLIENT_SECRET,
+            "code": code,
+            "state": state,
+        },
+    )
+    if token_res.status_code != 200:
+        raise HTTPException(status_code=400, detail="네이버 토큰 요청 실패")
+
+    access_token = token_res.json().get("access_token")
+
+    profile_res = requests.get(
+        "https://openapi.naver.com/v1/nid/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    if profile_res.status_code != 200:
+        raise HTTPException(status_code=400, detail="네이버 사용자 정보 요청 실패")
+
+    naver_info = profile_res.json()["response"]
+    naver_id = str(naver_info["id"])
+    email = naver_info.get("email") or f"{naver_id}@naver.com"
+    name = naver_info.get("name")
+    profile_image = naver_info.get("profile_image")
+
+    user = db.query(User).filter(
+        User.social_id == naver_id, User.social_provider == "naver"
+    ).first()
+    if not user:
+        user = User(
+            social_provider="naver",
+            social_id=naver_id,
+            email=email,
+            name=name,
+            profile_image=profile_image,
+            is_active=True,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    token = create_access_token(data={"user_id": user.user_id})
+    return RedirectResponse(f"{FRONTEND_REDIRECT}?token={token}")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -6,8 +6,8 @@ from app.routes import auth
 
 client = TestClient(app)
 
+# ✅ Google 로그인 테스트 ------------------------
 
-# ✅ 실패 케이스: 잘못된 토큰일 때
 def test_google_login_invalid_token():
     response = client.post(
         "/api/v1/auth/google-login", json={"id_token_str": "invalid_token"}
@@ -16,27 +16,76 @@ def test_google_login_invalid_token():
     assert response.json()["detail"] == "Invalid Google token"
 
 
-# ✅ 성공 케이스: mocking을 이용해서 구글 토큰 검증 우회
 @patch("app.routes.auth.id_token.verify_oauth2_token")
 def test_google_login_success(mock_verify_token):
-    # ✅ mocking된 구글 토큰 응답 값 정의
     mock_verify_token.return_value = {
-        "sub": "mocked_social_id_12345",
-        "email": "testuser@example.com",
-        "name": "테스트 사용자",
-        "picture": "http://test.image.url",
+        "sub": "mocked_google_id_12345",
+        "email": "googleuser@example.com",
+        "name": "구글 사용자",
+        "picture": "http://google.image.url",
     }
 
     response = client.post(
-        "/api/v1/auth/google-login", json={"id_token_str": "any_valid_token_string"}
+        "/api/v1/auth/google-login", json={"id_token_str": "mocked_token"}
     )
-
     assert response.status_code == 200
     data = response.json()
-
-    # ✅ 응답 필드 검증
-    assert data["user_id"] > 0
-    assert data["email"] == "testuser@example.com"
+    assert data["email"] == "googleuser@example.com"
     assert "access_token" in data
 
-    # ✅ JWT 토큰 유효성은 별도 테스트 가능 (간단 예시로 존재 확인)
+# ✅ Kakao 로그인 테스트 ------------------------
+
+@patch("app.routes.auth.requests.post")
+@patch("app.routes.auth.requests.get")
+def test_kakao_login_success(mock_get, mock_post):
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {
+        "access_token": "mock_kakao_access_token"
+    }
+
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "id": "kakao_mock_id_123",
+        "kakao_account": {"email": "kakaouser@example.com"},
+        "properties": {
+            "nickname": "카카오유저",
+            "profile_image": "http://kakao.img"
+        }
+    }
+
+    response = client.request(
+        method="GET",
+        url="/api/v1/auth/kakao/callback?code=mock_code",
+        follow_redirects=False
+    )
+
+    assert response.status_code == 307
+    assert response.headers["location"].startswith("http://localhost:5173/login?token=")
+
+# ✅ Naver 로그인 테스트 ------------------------
+
+@patch("app.routes.auth.requests.post")
+@patch("app.routes.auth.requests.get")
+def test_naver_login_success(mock_get, mock_post):
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {
+        "access_token": "mock_naver_access_token"
+    }
+
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "response": {
+            "id": "naver_mock_id_456",
+            "email": "naveruser@example.com",
+            "name": "네이버유저",
+            "profile_image": "http://naver.img"
+        }
+    }
+
+    response = client.request(
+        method="GET",
+        url="/api/v1/auth/naver/callback?code=mock_code&state=xyz",
+        follow_redirects=False
+    )
+    assert response.status_code == 307
+    assert response.headers["location"].startswith("http://localhost:5173/login?token=")


### PR DESCRIPTION
## ✨ 주요 변경사항
- 이슈 #4 
- 카카오 및 네이버 OAuth2 로그인 기능 추가
- 기존 Google 로그인 흐름과 통합
- `/api/v1/auth/kakao-login`, `/naver-login` 엔드포인트 추가
- 환경변수 예시 (`.env.example`)에 관련 키 추가
- 테스트 코드에 카카오/네이버 로그인 유효성 검증 로직 추가

## 🧪 테스트 결과
- pytest 기반 테스트 코드 통과
- 실제 토큰 값이 없을 경우 mock으로 정상 동작 확인

## 참고사항
- 프론트엔드 연동 시 provider에 따라 요청 분기 필요