### PR TITLE
feat: 사용자 정보 조회 및 수정 API 구현

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.routes import job
 from app.services import job_service
 from app.core.config import load_env, get_settings
-from app.routes import auth
+from app.routes import auth, user
 from app.models.user import Base
 from app.core.database import engine
 
@@ -39,3 +39,5 @@ def read_root():
 app.include_router(job.router, prefix="/api/v1/jobs", tags=["Jobs"])
 
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
+
+app.include_router(user.router, prefix="/api/v1/users", tags=["User"])

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -3,7 +3,7 @@
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, func
 from sqlalchemy.orm import declarative_base
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, HttpUrl
 from typing import Optional
 from datetime import datetime
 
@@ -53,4 +53,22 @@ class UserResponse(BaseModel):
     access_token: str
 
     class Config:
-        from_attribute = True
+        from_attributes = True
+
+# 내 정보 조회 시 반환할 스키마
+class UserOut(BaseModel):
+    user_id: int
+    email: EmailStr
+    name: Optional[str] = None
+    profile_image: Optional[HttpUrl] = None
+    is_active: bool
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+# 사용자 정보 수정 시 사용되는 요청용 스키마
+class UserUpdate(BaseModel):
+    name: Optional[str] = None
+    profile_image: Optional[HttpUrl] = None
+    email: Optional[EmailStr] = None

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.core.database import get_db
+from app.models.user import UserOut, UserUpdate, User
+from app.services import user_service
+from app.routes.auth import get_current_user
+
+router = APIRouter()
+
+# 현재 사용자 정보 조회
+@router.get("/me", response_model=UserOut)
+def read_my_user_info(
+    current_user: User = Depends(get_current_user),
+):
+    return current_user
+
+# 현재 사용자 정보 수정
+@router.put("/me", response_model=UserOut)
+def update_my_user_info(
+    user_update: UserUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        updated_user = user_service.update_user(db, current_user.user_id, user_update)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if updated_user is None:
+        raise HTTPException(status_code=404, detail="User Not Found")
+
+    return updated_user

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+from app.models.user import User, UserUpdate
+
+# 사용자 조회 함수
+def get_user_by_id(db: Session, user_id: int):
+    return db.query(User).filter(User.user_id == user_id).first()
+
+# 사용자 수정 함수
+def update_user(db: Session, user_id: int, user_update: UserUpdate):
+    user = db.query(User).filter(User.user_id == user_id).first()
+    if not user:
+        return None
+    
+    # 이메일 중복 체크
+    if user_update.email and user_update.email != user.email:
+        email_exists = db.query(User).filter(User.email == user_update.email).first()
+        if email_exists:
+            raise ValueError("이미 사용 중인 이메일입니다.")
+        
+    # 변경할 필드 적용
+    for key, value in user_update.dict(exclude_unset=True).items():
+        if hasattr(value, "__str__"):
+            value = str(value)
+        setattr(user, key, value)
+
+    db.commit()
+    db.refresh(user)
+    return user

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -19,10 +19,10 @@ def test_google_login_invalid_token():
 @patch("app.routes.auth.id_token.verify_oauth2_token")
 def test_google_login_success(mock_verify_token):
     mock_verify_token.return_value = {
-        "sub": "mocked_google_id_12345",
-        "email": "googleuser@example.com",
-        "name": "구글 사용자",
-        "picture": "http://google.image.url",
+        "sub": "mocked_social_id_12345",
+        "email": "testuser@example.com",
+        "name": "테스트 사용자",
+        "picture": "http://test.image.url",
     }
 
     response = client.post(
@@ -30,7 +30,7 @@ def test_google_login_success(mock_verify_token):
     )
     assert response.status_code == 200
     data = response.json()
-    assert data["email"] == "googleuser@example.com"
+    assert data["email"] == "testuser@example.com"
     assert "access_token" in data
 
 # ✅ Kakao 로그인 테스트 ------------------------

--- a/backend/tests/test_user.py
+++ b/backend/tests/test_user.py
@@ -1,0 +1,56 @@
+from fastapi.testclient import TestClient
+from datetime import timedelta
+from app.main import app
+from app.routes.auth import create_access_token
+
+client = TestClient(app)
+
+# ✅ 테스트용 JWT 토큰 동적 생성
+def get_token():
+    return create_access_token(data={"user_id": 3}, expires_delta=timedelta(minutes=60))
+
+def test_get_my_user_info_real_token():
+    token = get_token()
+    response = client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] in ["googleuser1@example.com", "googleuser2@example.com"]
+
+def test_update_my_user_info_real_token():
+    token = get_token()
+
+    # 현재 정보 확인
+    get_response = client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    current = get_response.json()
+
+    # 토글 방식: (1) → (2), (2) → (1)
+    if current["email"] == "googleuser1@example.com":
+        payload = {
+            "name": "구글 사용자 수정됨(2)",
+            "profile_image": "http://google.image.url/updated.png(2)",
+            "email": "googleuser2@example.com",
+        }
+    else:
+        payload = {
+            "name": "구글 사용자 수정됨(1)",
+            "profile_image": "http://google.image.url/updated.png(1)",
+            "email": "googleuser1@example.com",
+        }
+
+    response = client.put(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+        json=payload,
+    )
+    print("\n🔄 업데이트된 사용자 정보:", response.json())
+
+    assert response.status_code == 200
+    assert response.json()["name"] == payload["name"]
+    assert response.json()["profile_image"] == payload["profile_image"]
+    assert response.json()["email"] == payload["email"]


### PR DESCRIPTION
## 🚀 작업 개요  
이슈 #5 
사용자의 프로필 정보를 조회하고 수정할 수 있는 API를 구현하였습니다.  
JWT 기반 인증을 통해 본인의 정보만 수정/조회 가능하며, 기존 인증 로직과 통합되도록 구현했습니다.

---

## 🔧 주요 변경사항  

- `routes/user.py`  
  - `/api/v1/users/me` (GET): 로그인한 사용자의 정보 조회  
  - `/api/v1/users/me` (PUT): 이름, 프로필 이미지, 이메일 수정 기능 추가  

- `services/user_service.py`  
  - 사용자 정보 조회 및 수정 로직 분리  
  - `update_user_info()` 함수로 사용자 정보 수정 처리  

- `models/user.py`  
  - `UserUpdate` Pydantic 모델 정의  

- `routes/auth.py`  
  - JWT 토큰 생성 로직 정리 및 불필요한 임시 코드 제거  

- 테스트 코드 추가  
  - `tests/test_user.py`: JWT 자동 생성 및 사용자 정보 토글 방식 수정 테스트  
  - `tests/test_auth.py`: mock 데이터(email, name, profile_image) 최신화

---

## ✅ 테스트 결과  

- `tests/test_user.py`  
  - 사용자 정보 조회 및 수정 테스트 **성공**

- `tests/test_auth.py`  
  - 구글 로그인 성공/실패 시나리오 테스트 **성공**