### PR TITLE
feat: 직무·언어·프레임워크 선택 기반 페이지 추가

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,8 @@ import Jobs from './pages/JobsPage';
 import TrendPage from './pages/TrendPage';
 import ResumeAnalysisPage from './pages/ResumeAnalysisPage';
 import Header from './components/Header';
+import Jobanalysispage from './pages/Jobanalysispage';
+import RoadmapResult from './pages/Roadmapresult';
 
 import './global.css';
 
@@ -31,6 +33,8 @@ function App() {
         <Route path="/jobs" element={<Jobs />} />
         <Route path="/trend" element={<TrendPage />} />
         <Route path="/resume" element={<ResumeAnalysisPage />} />
+        <Route path="/analysis" element={<Jobanalysispage />} />
+        <Route path="/roadmap-result" element={<RoadmapResult />} />
       </Routes>
     </>
   );

--- a/frontend/src/pages/Jobanalysispage.css
+++ b/frontend/src/pages/Jobanalysispage.css
@@ -1,0 +1,70 @@
+.tab-bar {
+  display: flex;
+  align-items: center;
+  padding: 16px 24px;
+  gap: 12px;
+}
+
+.tab {
+  padding: 8px 16px;
+  border: none;
+  background-color: #1e90ff;
+  border-radius: 4px;
+  cursor: pointer;
+  color: white;
+}
+
+.tab.active {
+  background-color: #eee;
+  color: black;
+}
+
+.analyze-btn {
+  margin-left: auto;
+  padding: 8px 20px;
+  background-color: #1e90ff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.section {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  margin: 16px 24px;
+  padding: 16px;
+}
+
+.section h3 {
+  margin-bottom: 12px;
+  font-size: 16px;
+}
+
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.button-group button {
+  padding: 8px 14px;
+  background-color: #f2f2f2;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.button-group button:hover {
+  background-color: #d0e9ff;
+}
+
+.button-group button.selected {
+  background-color: #1e90ff;
+  color: white;
+}
+
+.hidden {
+  display: none;
+}

--- a/frontend/src/pages/Jobanalysispage.jsx
+++ b/frontend/src/pages/Jobanalysispage.jsx
@@ -1,0 +1,142 @@
+// 📄 src/pages/Analysis.jsx
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Header from '../components/Header';
+import "./Jobanalysispage.css";
+
+function Analysis() {
+  const navigate = useNavigate();
+  const [selectedJob, setSelectedJob] = useState('backend');
+  const [selectedSkills, setSelectedSkills] = useState([]);
+
+  const selectJob = (job) => {
+    setSelectedJob(job);
+    setSelectedSkills([]); // 직무 바뀔 때 선택 초기화
+  };
+
+  const toggleSkill = (skill) => {
+    setSelectedSkills((prev) =>
+      prev.includes(skill) ? prev.filter((s) => s !== skill) : [...prev, skill]
+    );
+  };
+
+  const generateGptRoadmap = async () => {
+    if (selectedSkills.length === 0) {
+      alert("기술을 하나 이상 선택해주세요!");
+      return;
+    }
+
+    try {
+      const res = await fetch("http://localhost:8000/api/v1/roadmap", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          job: selectedJob,
+          skills: selectedSkills
+        })
+      });
+
+      if (!res.ok) {
+        throw new Error("서버 응답 오류");
+      }
+
+      const result = await res.json();
+      console.log("📊 분석 결과:", result);
+
+      // 예시: 결과 페이지로 이동하거나 상태 저장 가능
+      navigate("/roadmap-result", { state: result });
+
+    } catch (error) {
+      console.error("❌ 분석 실패:", error);
+      alert("분석 중 오류가 발생했습니다.");
+      
+    }
+  };
+
+  return (
+    <div>
+      {/* 탭바 */}
+      <div className="tab-bar">
+        <button className="tab active" onClick={() => navigate("/resume")}>PDF분석</button>
+        <button className="tab">직무분석</button>
+        <button className="analyze-btn" onClick={generateGptRoadmap}>분석시작</button>
+      </div>
+
+      {/* 직군 선택 */}
+      <section className="section">
+        <h3>개발 직군</h3>
+        <div className="button-group" id="job-buttons">
+          <button onClick={() => selectJob("Backend")} className={selectedJob === "Backend" ? "selected" : ""}>백엔드</button>
+          <button onClick={() => selectJob("Frontend")} className={selectedJob === "Frontend" ? "selected" : ""}>프론트엔드</button>
+          <button onClick={() => selectJob("Mobile")} className={selectedJob === "Mobile" ? "selected" : ""}>모바일</button>
+          <button onClick={() => selectJob("AL/ML")} className={selectedJob === "AL/ML" ? "selected" : ""}>AI/ML</button>
+          <button onClick={() => selectJob("etc")} className={selectedJob === "etc" ? "selected" : ""}>기타(DB / 클라우드)</button>
+        </div>
+      </section>
+
+      {/* 카테고리별 언어 및 도구 */}
+      {renderCategory("Backend", [
+        ["Python", "Java", "Node.js", "Ruby", "Go", "Rust", "Kotlin", "TypeScript"],
+        ["Django", "Spring Boot", "Express.js", "Laravel", "NestJS", "Flask", "FastAPI", "Gin", "Ruby on Rails"]
+      ], selectedJob, selectedSkills, toggleSkill)}
+
+      {renderCategory("Frontend", [
+        ["HTML", "CSS", "JavaScript", "TypeScript"],
+        ["React", "Vue.js", "Angular", "Next.js", "Svelte", "Nust.js"]
+      ], selectedJob, selectedSkills, toggleSkill)}
+
+      {renderCategory("Mobile", [
+        ["Kotlin", "JavaScript", "Swift", "Dart"],
+        ["Flutter", "React Native"]
+      ], selectedJob, selectedSkills, toggleSkill)}
+
+      {renderCategory("AL/ML", [
+        ["Python", "R", "SQL"],
+        ["TensorFlow", "PyTorch", "HuggingFace", "Scikit-learn", "Transformers", "LangChain"]
+      ], selectedJob, selectedSkills, toggleSkill)}
+
+      {renderCategory("etc", [
+        ["MySQL", "PostgreSQL", "MongoDB", "Redis", "SQLite", "Oracle"],
+        ["AWS", "GCP", "Azure", "Docker", "Kubernetes", "Terraform", "Jenkins", "GitHub Actions", "Heroku", "Vercel"]
+      ], selectedJob, selectedSkills, toggleSkill)}
+    </div>
+  );
+}
+
+// 카테고리 렌더링 함수
+function renderCategory(type, [langs, tools], selectedJob, selectedSkills, toggleSkill) {
+  if (type !== selectedJob) return null;
+
+  return (
+    <section className={`section category ${type}`} key={type}>
+      <h3>{type === "etc" ? "DB" : `언어 (${type})`}</h3>
+      <div className="button-group">
+        {langs.map((lang) => (
+          <button
+            key={lang}
+            onClick={() => toggleSkill(lang)}
+            className={selectedSkills.includes(lang) ? "selected" : ""}
+          >
+            {lang}
+          </button>
+        ))}
+      </div>
+      <h3>{type === "etc" ? "클라우드" : `프레임워크/도구 (${type})`}</h3>
+      <div className="button-group">
+        {tools.map((tool) => (
+          <button
+            key={tool}
+            onClick={() => toggleSkill(tool)}
+            className={selectedSkills.includes(tool) ? "selected" : ""}
+          >
+            {tool}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default Analysis;

--- a/frontend/src/pages/Roadmapresult.jsx
+++ b/frontend/src/pages/Roadmapresult.jsx
@@ -1,0 +1,13 @@
+import { useLocation } from "react-router-dom";
+
+export default function RoadmapResult() {
+  const location = useLocation();
+  const result = location.state;
+
+  return (
+    <div>
+      <h2>분석 결과</h2>
+      <pre>{JSON.stringify(result, null, 2)}</pre>
+    </div>
+  );
+}


### PR DESCRIPTION
사용자가 직무, 언어, 프레임워크/도구를 선택할 수 있는 UI 페이지 추가
-직군 선택 버튼 그룹 구성
-카테고리별 기술 스택 선택 UI 구성
-상태 관리에 useState 사용

React Router를 사용하여 분석 페이지 간 이동 기능 추가
-App.jsx에 Route 설정 추가
