### PR TITLE
fix: JobORM 모델 변경에 따라 service 로직 수정

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,6 +1,6 @@
 import os
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, declarative_base
 from dotenv import load_dotenv
 
 # ✅ .env 파일 로드 (.env 환경변수 사용 가능하게 설정)
@@ -43,6 +43,9 @@ SessionLocal = sessionmaker(
     autoflush=False,
     bind=engine,
 )
+
+# 공통 Base 클래스 정의
+Base = declarative_base()
 
 
 # ✅ FastAPI Dependency로 사용할 수 있는 DB 세션 생성 함수

--- a/backend/app/services/keyword_service.py
+++ b/backend/app/services/keyword_service.py
@@ -1,11 +1,13 @@
 # backend/app/services/keyword_service.py
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../ai")))
 
 import uuid
 import shutil
-import os
 import logging
 from fastapi import UploadFile
-from ai.extractor import extract_keywords_from_pdf  # AI 키워드 추출 함수
+from extractor import extract_keywords_from_pdf  # AI 키워드 추출 함수
 from app.core.database import SessionLocal
 from app.models.keyword import Keyword
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #번호 없음

## 📝작업 내용

> - `JobORM` 모델의 PK 컬럼명을 `id` → `job_post_id`로 수정
> - 기존 service 로직에서 `job.id`를 `job.job_post_id`로 변경
> - 기술스택 파싱 관련 불필요한 `json.loads` 처리 제거