### PR TITLE
fix: 로그아웃 시 localStorage 전체 정리로 실제 로그아웃 처리

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -11,7 +11,7 @@ import {
   MenuItem,
 } from '@mui/material';
 import { useState } from 'react';
-
+import logoImg from '../assets/logo.png';
 import './Header.css';
 
 export default function Header({ userInfo, setUserInfo }) {
@@ -19,10 +19,19 @@ export default function Header({ userInfo, setUserInfo }) {
   const [anchorEl, setAnchorEl] = useState(null);
 
   const handleLogout = () => {
-    localStorage.removeItem("userInfo");
-    setUserInfo(null);
-    navigate('/');
-  };
+  localStorage.removeItem("userInfo");
+  localStorage.removeItem("token");
+  localStorage.removeItem("access_token");
+  localStorage.removeItem("userId");
+  localStorage.removeItem("userNick");
+  localStorage.removeItem("signupData");
+  localStorage.removeItem("kakao_state");
+  localStorage.removeItem("com.naverid.oauth.state_token");
+
+  setUserInfo(null);
+  navigate('/');
+};
+
 
   const handleMenuOpen = (event) => setAnchorEl(event.currentTarget);
   const handleMenuClose = () => setAnchorEl(null);
@@ -31,7 +40,7 @@ export default function Header({ userInfo, setUserInfo }) {
     <>
       <header className="header">
         <Link to="/">
-          <img src="/logo.png" alt="로고" className="logo" />
+          <img src={logoImg} alt="로고" className="logo" />
         </Link>
 
         <div className="auth-links">


### PR DESCRIPTION
로그인 토큰 및 사용자 정보가 남아 세션이 유지되던 문제를 해결하기 위해,
로그아웃 시 localStorage를 초기화하도록 수정